### PR TITLE
refactor: optimize FeatureFlagProvider with thread safety and protocol improvements

### DIFF
--- a/CDC_Interview/CDC_Interview.xcodeproj/project.pbxproj
+++ b/CDC_Interview/CDC_Interview.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		924C4AA82E4D7D430033297F /* DataSourceResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924C4AA12E4D7D430033297F /* DataSourceResource.swift */; };
 		924C4AA92E4D7D430033297F /* RemoteDataSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924C4AA42E4D7D430033297F /* RemoteDataSourceProvider.swift */; };
 		924C4AAA2E4D7D430033297F /* DataSourceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924C4A9E2E4D7D430033297F /* DataSourceConfiguration.swift */; };
+		924C4AAC2E4D80930033297F /* FeatureFlagProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924C4AAB2E4D80930033297F /* FeatureFlagProviderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		924C4AA12E4D7D430033297F /* DataSourceResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceResource.swift; sourceTree = "<group>"; };
 		924C4AA32E4D7D430033297F /* LocalDataSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataSourceProvider.swift; sourceTree = "<group>"; };
 		924C4AA42E4D7D430033297F /* RemoteDataSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDataSourceProvider.swift; sourceTree = "<group>"; };
+		924C4AAB2E4D80930033297F /* FeatureFlagProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagProviderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +174,7 @@
 		1FBEC5A12C940DE300732A9C /* CDC_InterviewTests */ = {
 			isa = PBXGroup;
 			children = (
+				924C4AAB2E4D80930033297F /* FeatureFlagProviderTests.swift */,
 				924C49D62E4C89040033297F /* DependencyTests.swift */,
 				924C4A092E4CED230033297F /* LocalDataProviderTests.swift */,
 				1FBEC5A22C940DE300732A9C /* CDC_InterviewTests.swift */,
@@ -486,6 +489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				924C4AAC2E4D80930033297F /* FeatureFlagProviderTests.swift in Sources */,
 				924C4A972E4D6E880033297F /* DataSourceResourceTests.swift in Sources */,
 				924C4A992E4D6F1B0033297F /* DataSourceConfigurationTests.swift in Sources */,
 				924C4A9B2E4D71130033297F /* USDPriceUseCaseTests.swift in Sources */,

--- a/CDC_Interview/CDC_Interview/Application/AppDelegate.swift
+++ b/CDC_Interview/CDC_Interview/Application/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             )
         }
         
-        Dependency.shared.register(FeatureFlagProvider.self) { resolver in
+        Dependency.shared.register(FeatureFlagProviderProtocol.self) { resolver in
             return FeatureFlagProvider()
         }
         

--- a/CDC_Interview/CDC_Interview/Layer/Presentation/ListView/SwiftUIListViewController.swift
+++ b/CDC_Interview/CDC_Interview/Layer/Presentation/ListView/SwiftUIListViewController.swift
@@ -42,10 +42,10 @@ class ListViewModel: ObservableObject {
 
     private let dependency: Dependency = .shared
     private let useCase: USDPriceUseCase = .shared
-    private let featureFlagProvider: FeatureFlagProvider
+    private let featureFlagProvider: FeatureFlagProviderProtocol
 
     init() {
-        self.featureFlagProvider = dependency.resolve(FeatureFlagProvider.self)!
+        self.featureFlagProvider = dependency.resolve(FeatureFlagProviderProtocol.self)!
     }
 
     func fetchItems() async {

--- a/CDC_Interview/CDC_Interview/Layer/Presentation/SettingViewController.swift
+++ b/CDC_Interview/CDC_Interview/Layer/Presentation/SettingViewController.swift
@@ -23,10 +23,10 @@ class SettingModel: ObservableObject {
         }
     }
     
-    let featureFlagProvider: FeatureFlagProvider
-    
+    let featureFlagProvider: FeatureFlagProviderProtocol
+
     init() {
-        self.featureFlagProvider = Dependency.shared.resolve(FeatureFlagProvider.self)!
+        self.featureFlagProvider = Dependency.shared.resolve(FeatureFlagProviderProtocol.self)!
         self.supportEUR = self.featureFlagProvider.getValue(flag: .supportEUR)
     }
 }

--- a/CDC_Interview/CDC_Interview/Layer/Shared/FeatureFlagProvider.swift
+++ b/CDC_Interview/CDC_Interview/Layer/Shared/FeatureFlagProvider.swift
@@ -7,26 +7,58 @@ enum FeatureFlagType {
     case supportEUR
 }
 
-class FeatureFlagProvider {
-    let flagsRelay: BehaviorRelay<[FeatureFlagType: Bool]> = .init(
-        value: [
-            .supportEUR: false
-        ]
-    )
-    
+/// Protocol defining the interface for feature flag management
+/// Provides methods to observe, retrieve, and update feature flag values
+protocol FeatureFlagProviderProtocol {
+
+    /// Observes changes to a specific feature flag value
+    /// - Parameter flag: The feature flag to observe
+    /// - Returns: Observable that emits the current flag value and any subsequent changes
+    func observeFlagValue(flag: FeatureFlagType) -> Observable<Bool>
+
+    /// Gets the current value of a feature flag
+    /// - Parameter flag: The feature flag to query
+    /// - Returns: Current boolean value of the flag
+    func getValue(flag: FeatureFlagType) -> Bool
+
+    /// Updates the value of a feature flag
+    /// - Parameters:
+    ///   - flag: The feature flag to update
+    ///   - newValue: The new boolean value to set
+    func update(flag: FeatureFlagType, newValue: Bool)
+}
+
+class FeatureFlagProvider: FeatureFlagProviderProtocol {
+
+    // MARK: - FeatureFlagProvider
+    private let flagsRelay: BehaviorRelay<[FeatureFlagType: Bool]>
+    private let lock = NSLock() // Thread safety
+
+    init() {
+        self.flagsRelay = BehaviorRelay(
+            value: [
+                .supportEUR: false
+            ]
+        )
+    }
+
     func observeFlagValue(flag: FeatureFlagType) -> Observable<Bool> {
-        flagsRelay.map {
-            $0[flag] ?? false
-        }
+        return flagsRelay
+            .map { $0[flag] ?? false }
+            .distinctUntilChanged() // Performance: avoid duplicate emissions
     }
 
     func getValue(flag: FeatureFlagType) -> Bool {
-        flagsRelay.value[flag] ?? false
+        lock.lock()
+        defer { lock.unlock() }
+        return flagsRelay.value[flag] ?? false
     }
 
     func update(flag: FeatureFlagType, newValue: Bool) {
+        lock.lock()
         var existing = flagsRelay.value
         existing[flag] = newValue
         flagsRelay.accept(existing)
+        lock.unlock()
     }
 }

--- a/CDC_Interview/CDC_InterviewTests/FeatureFlagProviderTests.swift
+++ b/CDC_Interview/CDC_InterviewTests/FeatureFlagProviderTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+import RxSwift
+import RxTest
+@testable import CDC_Interview
+
+class FeatureFlagProviderTests: XCTestCase {
+
+    var sut: FeatureFlagProvider!
+    var disposeBag: DisposeBag!
+
+    override func setUp() {
+        super.setUp()
+        sut = FeatureFlagProvider()
+        disposeBag = DisposeBag()
+    }
+
+    override func tearDown() {
+        sut = nil
+        disposeBag = nil
+        super.tearDown()
+    }
+
+    // MARK: - Core Functionality Tests
+
+    func testDefaultValue() {
+        XCTAssertFalse(sut.getValue(flag: .supportEUR))
+    }
+
+    func testUpdateFlag() {
+        // Given
+        XCTAssertFalse(sut.getValue(flag: .supportEUR))
+
+        // When
+        sut.update(flag: .supportEUR, newValue: true)
+
+        // Then
+        XCTAssertTrue(sut.getValue(flag: .supportEUR))
+    }
+
+    func testObserveFlagValue() {
+        // Given
+        var receivedValues: [Bool] = []
+        let expectation = XCTestExpectation(description: "Flag value observed")
+        expectation.expectedFulfillmentCount = 2
+
+        sut.observeFlagValue(flag: .supportEUR)
+            .subscribe(onNext: { value in
+                receivedValues.append(value)
+                expectation.fulfill()
+            })
+            .disposed(by: disposeBag)
+
+        // When
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.sut.update(flag: .supportEUR, newValue: true)
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedValues, [false, true])
+    }
+
+    // MARK: - Thread Safety Tests
+
+    func testThreadSafety() {
+        let expectation = XCTestExpectation(description: "Thread safety test")
+        expectation.expectedFulfillmentCount = 100
+
+        // Simulate concurrent access
+        for i in 0..<100 {
+            DispatchQueue.global().async {
+                self.sut.update(flag: .supportEUR, newValue: i % 2 == 0)
+                let _ = self.sut.getValue(flag: .supportEUR)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+        // If we reach here without crashes, thread safety is working
+    }
+
+    // MARK: - Performance Tests
+
+    func testDistinctUntilChanged() {
+        // Given
+        var emissionCount = 0
+        let expectation = XCTestExpectation(description: "Distinct emissions")
+        expectation.expectedFulfillmentCount = 2 // Initial + one change
+
+        sut.observeFlagValue(flag: .supportEUR)
+            .subscribe(onNext: { _ in
+                emissionCount += 1
+                expectation.fulfill()
+            })
+            .disposed(by: disposeBag)
+
+        // When - Update with same value multiple times
+        sut.update(flag: .supportEUR, newValue: true)
+        sut.update(flag: .supportEUR, newValue: true) // Should not emit
+        sut.update(flag: .supportEUR, newValue: true) // Should not emit
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(emissionCount, 2) // Initial false + changed to true
+    }
+}


### PR DESCRIPTION
refactor: optimize FeatureFlagProvider with thread safety and protocol improvements

- Rename protocol from FeatureFlagProviderType to FeatureFlagProviderProtocol
- Add comprehensive documentation comments for protocol methods
- Fix thread safety issues with NSLock for concurrent access
- Add distinctUntilChanged to prevent duplicate emissions
- Update dependency injection to use protocol abstraction
- Add focused unit tests covering core functionality and thread safety
- Remove over-engineered extensions to maintain simplicity

Fixes: Thread safety vulnerabilities and performance issues